### PR TITLE
#15/#18 タイマーモードの遷移をできるようにする

### DIFF
--- a/lib/models/timer_loop.dart
+++ b/lib/models/timer_loop.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_pomodoro/models/timer_mode.dart';
+
+class TimerLoop {
+  late TimerMode _timerMode;
+  late int _remainingSeconds;
+  late Timer _timer;
+  late VoidCallback _onTick;
+  late VoidCallback _onEnd;
+
+  TimerLoop({
+    required TimerMode timerMode,
+    required VoidCallback onTick,
+    required VoidCallback onEnd,
+  }) {
+    _timerMode = timerMode;
+    _remainingSeconds = _getInitialSeconds();
+    _onTick = onTick;
+    _onEnd = onEnd;
+  }
+
+  int get remainingSeconds => _remainingSeconds;
+
+  static const Map<TimerMode, int> _initialSeconds = {
+    TimerMode.work: 25 * 60,
+    TimerMode.shortBreak: 5 * 60,
+  };
+
+  int _getInitialSeconds() {
+    return _initialSeconds[_timerMode]!;
+  }
+
+  void decrementRemainingSeconds() {
+    _remainingSeconds--;
+  }
+
+  void start() {
+    const oneSec = Duration(seconds: 1);
+    _timer = Timer.periodic(oneSec, (Timer timer) {
+      _onTick();
+    });
+  }
+
+  void switchAndRestart() {
+    _timer.cancel();
+
+    if (_timerMode == TimerMode.work) {
+      _timerMode = TimerMode.shortBreak;
+    } else {
+      _timerMode = TimerMode.work;
+    }
+
+    _remainingSeconds = _getInitialSeconds();
+
+    // setState(() {}) を呼び出す
+    _onEnd();
+
+    start();
+  }
+
+  void dispose() {
+    _timer.cancel();
+  }
+}

--- a/lib/models/timer_mode.dart
+++ b/lib/models/timer_mode.dart
@@ -1,0 +1,4 @@
+enum TimerMode {
+  work,
+  shortBreak,
+}

--- a/lib/widgets/clock.dart
+++ b/lib/widgets/clock.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_pomodoro/models/dount_chart/chart_data.dart';
+import 'package:flutter_pomodoro/models/timer_mode.dart';
 import 'package:flutter_pomodoro/widgets/donut_chart.dart';
 import 'package:flutter_pomodoro/widgets/timer_dial.dart';
 
@@ -19,7 +20,9 @@ class Clock extends StatelessWidget {
           ],
           chartStrokeWidth: 10,
         ),
-        const TimerDial(),
+        const TimerDial(
+          timerMode: TimerMode.work,
+        ),
       ],
     );
   }

--- a/lib/widgets/clock.dart
+++ b/lib/widgets/clock.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_pomodoro/models/dount_chart/chart_data.dart';
-import 'package:flutter_pomodoro/models/timer_mode.dart';
 import 'package:flutter_pomodoro/widgets/donut_chart.dart';
 import 'package:flutter_pomodoro/widgets/timer_dial.dart';
 
@@ -20,9 +19,7 @@ class Clock extends StatelessWidget {
           ],
           chartStrokeWidth: 10,
         ),
-        const TimerDial(
-          timerMode: TimerMode.work,
-        ),
+        const TimerDial(),
       ],
     );
   }

--- a/lib/widgets/timer_dial.dart
+++ b/lib/widgets/timer_dial.dart
@@ -1,17 +1,25 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_pomodoro/models/timer_mode.dart';
 
 class TimerDial extends StatefulWidget {
-  const TimerDial({super.key});
+  final TimerMode timerMode;
+
+  const TimerDial({Key? key, required this.timerMode}) : super(key: key);
 
   @override
   State<TimerDial> createState() => _TimerDialState();
 }
 
 class _TimerDialState extends State<TimerDial> {
-  static const int startSeconds = 25 * 60;
-  int _remainingSeconds = startSeconds;
+  static const Map<TimerMode, int> _initialSeconds = {
+    TimerMode.work: 25 * 60,
+    TimerMode.shortBreak: 5 * 60,
+  };
+
+  late int _remainingSeconds = _initialSeconds[widget.timerMode]!;
+
   Timer? _timer;
 
   @override

--- a/lib/widgets/timer_dial.dart
+++ b/lib/widgets/timer_dial.dart
@@ -1,6 +1,5 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
+import 'package:flutter_pomodoro/models/timer_loop.dart';
 import 'package:flutter_pomodoro/models/timer_mode.dart';
 
 class TimerDial extends StatefulWidget {
@@ -11,47 +10,32 @@ class TimerDial extends StatefulWidget {
 }
 
 class _TimerDialState extends State<TimerDial> {
-  static const Map<TimerMode, int> _initialSeconds = {
-    TimerMode.work: 25 * 60,
-    TimerMode.shortBreak: 5 * 60,
-  };
-
-  late TimerMode _timerMode;
-
-  late int _remainingSeconds;
-
-  Timer? _timer;
+  late TimerLoop _timerLoop;
 
   @override
   void initState() {
     super.initState();
 
-    _timerMode = TimerMode.work;
-    _setRemainingSeconds();
-
-    startTimer();
-  }
-
-  void _setRemainingSeconds() {
-    _remainingSeconds = _initialSeconds[_timerMode]!;
-  }
-
-  void startTimer() {
-    const oneSec = Duration(seconds: 1);
-    _timer = Timer.periodic(oneSec, (Timer timer) {
-      if (_remainingSeconds == 0) {
-        endTimer();
-      } else {
-        setState(() {
-          _remainingSeconds--;
+    _timerLoop = TimerLoop(
+        timerMode: TimerMode.work,
+        onTick: () {
+          if (_timerLoop.remainingSeconds == 0) {
+            _timerLoop.switchAndRestart();
+          } else {
+            setState(() {
+              _timerLoop.decrementRemainingSeconds();
+            });
+          }
+        },
+        onEnd: () {
+          setState(() {});
         });
-      }
-    });
+    _timerLoop.start();
   }
 
   String getRemainingTime() {
-    int remainingMinutes = _remainingSeconds ~/ 60;
-    int remainingSeconds = _remainingSeconds % 60;
+    int remainingMinutes = _timerLoop.remainingSeconds ~/ 60;
+    int remainingSeconds = _timerLoop.remainingSeconds % 60;
     String remainingTime =
         '${remainingMinutes.toString().padLeft(2, '0')}:${remainingSeconds.toString().padLeft(2, '0')}';
     return remainingTime;
@@ -68,24 +52,7 @@ class _TimerDialState extends State<TimerDial> {
 
   @override
   void dispose() {
-    _timer?.cancel();
+    _timerLoop.dispose();
     super.dispose();
-  }
-
-  void endTimer() {
-    // タイマーのモードを切り替えて再スタート
-
-    _timer?.cancel();
-
-    if (_timerMode == TimerMode.work) {
-      _timerMode = TimerMode.shortBreak;
-    } else {
-      _timerMode = TimerMode.work;
-    }
-
-    _setRemainingSeconds();
-
-    setState(() {});
-    startTimer();
   }
 }

--- a/lib/widgets/timer_dial.dart
+++ b/lib/widgets/timer_dial.dart
@@ -4,9 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_pomodoro/models/timer_mode.dart';
 
 class TimerDial extends StatefulWidget {
-  final TimerMode timerMode;
-
-  const TimerDial({Key? key, required this.timerMode}) : super(key: key);
+  const TimerDial({Key? key}) : super(key: key);
 
   @override
   State<TimerDial> createState() => _TimerDialState();
@@ -18,21 +16,31 @@ class _TimerDialState extends State<TimerDial> {
     TimerMode.shortBreak: 5 * 60,
   };
 
-  late int _remainingSeconds = _initialSeconds[widget.timerMode]!;
+  late TimerMode _timerMode;
+
+  late int _remainingSeconds;
 
   Timer? _timer;
 
   @override
   void initState() {
     super.initState();
+
+    _timerMode = TimerMode.work;
+    _setRemainingSeconds();
+
     startTimer();
+  }
+
+  void _setRemainingSeconds() {
+    _remainingSeconds = _initialSeconds[_timerMode]!;
   }
 
   void startTimer() {
     const oneSec = Duration(seconds: 1);
     _timer = Timer.periodic(oneSec, (Timer timer) {
       if (_remainingSeconds == 0) {
-        timer.cancel();
+        endTimer();
       } else {
         setState(() {
           _remainingSeconds--;
@@ -62,5 +70,22 @@ class _TimerDialState extends State<TimerDial> {
   void dispose() {
     _timer?.cancel();
     super.dispose();
+  }
+
+  void endTimer() {
+    // タイマーのモードを切り替えて再スタート
+
+    _timer?.cancel();
+
+    if (_timerMode == TimerMode.work) {
+      _timerMode = TimerMode.shortBreak;
+    } else {
+      _timerMode = TimerMode.work;
+    }
+
+    _setRemainingSeconds();
+
+    setState(() {});
+    startTimer();
   }
 }

--- a/test/widgets/timer_dial_test.dart
+++ b/test/widgets/timer_dial_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_pomodoro/models/timer_mode.dart';
 import 'package:flutter_pomodoro/widgets/timer_dial.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -9,9 +8,7 @@ void main() {
         (WidgetTester tester) async {
       await tester.pumpWidget(
         const MaterialApp(
-          home: TimerDial(
-            timerMode: TimerMode.work,
-          ),
+          home: TimerDial(),
         ),
       );
       expect(find.text('25:00'), findsOneWidget);
@@ -21,9 +18,7 @@ void main() {
         (WidgetTester tester) async {
       await tester.pumpWidget(
         const MaterialApp(
-          home: TimerDial(
-            timerMode: TimerMode.work,
-          ),
+          home: TimerDial(),
         ),
       );
       await tester.pump(const Duration(seconds: 1));
@@ -34,24 +29,47 @@ void main() {
         (WidgetTester tester) async {
       await tester.pumpWidget(
         const MaterialApp(
-          home: TimerDial(
-            timerMode: TimerMode.work,
-          ),
+          home: TimerDial(),
         ),
       );
       await tester.pump(const Duration(minutes: 25));
       expect(find.text('00:00'), findsOneWidget);
     });
 
-    testWidgets('should display 05:00 initially in short break mode',
+    testWidgets(
+        'should display 05:00 after 25 minutes and 1 second in work mode, then transisting to short break mode',
         (WidgetTester tester) async {
       await tester.pumpWidget(
         const MaterialApp(
-          home: TimerDial(timerMode: TimerMode.shortBreak),
+          home: TimerDial(),
         ),
       );
-
+      await tester.pump(const Duration(minutes: 25, seconds: 1));
       expect(find.text('05:00'), findsOneWidget);
+    });
+
+    testWidgets(
+        'should display 00:00 after 30 minutes and 1 second in work mode, then transisting to short break mode',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: TimerDial(),
+        ),
+      );
+      await tester.pump(const Duration(minutes: 30, seconds: 1));
+      expect(find.text('00:00'), findsOneWidget);
+    });
+
+    testWidgets(
+        'should display 25:00 after 30 minutes and 2 second in work mode, then transisting to work mode',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: TimerDial(),
+        ),
+      );
+      await tester.pump(const Duration(minutes: 30, seconds: 2));
+      expect(find.text('25:00'), findsOneWidget);
     });
   });
 }

--- a/test/widgets/timer_dial_test.dart
+++ b/test/widgets/timer_dial_test.dart
@@ -1,38 +1,57 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_pomodoro/models/timer_mode.dart';
 import 'package:flutter_pomodoro/widgets/timer_dial.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('TimerDial', () {
-    testWidgets('should display 25:00 initially', (WidgetTester tester) async {
+    testWidgets('should display 25:00 initially in work mode',
+        (WidgetTester tester) async {
       await tester.pumpWidget(
         const MaterialApp(
-          home: TimerDial(),
+          home: TimerDial(
+            timerMode: TimerMode.work,
+          ),
         ),
       );
       expect(find.text('25:00'), findsOneWidget);
     });
 
-    testWidgets('should display 24:59 after 1 second',
+    testWidgets('should display 24:59 after 1 second in work mode',
         (WidgetTester tester) async {
       await tester.pumpWidget(
         const MaterialApp(
-          home: TimerDial(),
+          home: TimerDial(
+            timerMode: TimerMode.work,
+          ),
         ),
       );
       await tester.pump(const Duration(seconds: 1));
       expect(find.text('24:59'), findsOneWidget);
     });
 
-    testWidgets('should display 00:00 after 25 minutes',
+    testWidgets('should display 00:00 after 25 minutes in work mode',
         (WidgetTester tester) async {
       await tester.pumpWidget(
         const MaterialApp(
-          home: TimerDial(),
+          home: TimerDial(
+            timerMode: TimerMode.work,
+          ),
         ),
       );
       await tester.pump(const Duration(minutes: 25));
       expect(find.text('00:00'), findsOneWidget);
+    });
+
+    testWidgets('should display 05:00 initially in short break mode',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: TimerDial(timerMode: TimerMode.shortBreak),
+        ),
+      );
+
+      expect(find.text('05:00'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
Close #18 

作業タイマー -> 休憩タイマー -> 作業タイマー -> 休憩タイマー

のように遷移できるようにしました

タイマーのループ及びスイッチャーは `TimerLoop` クラスが賄うようにしました